### PR TITLE
bug/wsl-open-sso-url

### DIFF
--- a/internal/aws/credentials.go
+++ b/internal/aws/credentials.go
@@ -219,14 +219,40 @@ func openBrowser(url string) error {
 	switch runtime.GOOS {
 	case "windows":
 		cmd = "cmd"
-		args = []string{"/c", "start"}
+		args = []string{"/c", "start", ""}
 	case "darwin":
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
+		// Check if running in WSL
+		if isWSL() {
+			// Use Windows browser from WSL
+			// Note: empty string after 'start' is the title parameter
+			cmd = "cmd.exe"
+			args = []string{"/c", "start", ""}
+		} else {
+			cmd = "xdg-open"
+		}
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()
+}
+
+// isWSL checks if the current environment is Windows Subsystem for Linux
+func isWSL() bool {
+	// Check for WSL-specific environment variables
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	
+	// Check /proc/version for Microsoft/WSL
+	if data, err := os.ReadFile("/proc/version"); err == nil {
+		version := strings.ToLower(string(data))
+		if strings.Contains(version, "microsoft") || strings.Contains(version, "wsl") {
+			return true
+		}
+	}
+	
+	return false
 }
 
 func isRetryableError(err error) bool {


### PR DESCRIPTION
# Add WSL Browser Support

## Overview
Enhanced WSL (Windows Subsystem for Linux) support by automatically detecting WSL environments and using the Windows browser for SSO authentication flows.

## Changes Made

### Enhanced Browser Opening Logic (`internal/aws/credentials.go`)

**Added WSL Detection Function**
- Implemented `isWSL()` helper function to detect if running in a WSL environment
- Checks for WSL-specific environment variables (`WSL_DISTRO_NAME`, `WSL_INTEROP`)
- Fallback check by reading `/proc/version` for Microsoft/WSL indicators

**Improved `openBrowser()` Function**
- Added WSL-specific handling in the Linux code path
- When running in WSL, uses `cmd.exe /c start` to invoke the Windows browser
- Fixed Windows command to include empty string parameter after `start` (required title parameter)
- Maintains existing behavior for native Linux environments using `xdg-open`

## Technical Details

### WSL Detection Strategy
The implementation uses a two-tier detection approach:
1. **Environment Variables**: Fast check for `WSL_DISTRO_NAME` or `WSL_INTEROP`
2. **Filesystem Check**: Reads `/proc/version` and checks for "microsoft" or "wsl" strings

### Cross-Platform Browser Invocation
- **Windows**: `cmd /c start "" <url>`
- **macOS**: `open <url>`
- **Linux (native)**: `xdg-open <url>`
- **Linux (WSL)**: `cmd.exe /c start "" <url>` (uses Windows browser)

## Benefits

- ✅ Seamless SSO authentication experience for WSL users
- ✅ Automatic detection - no user configuration required
- ✅ Maintains backward compatibility with all existing platforms
- ✅ Aligns with existing documentation that recommends WSL for Windows users
